### PR TITLE
Expose /dev/zfs inside all containers

### DIFF
--- a/container.go
+++ b/container.go
@@ -145,6 +145,14 @@ func (md *MDocker) CreateContainer(h *http.Request, request *rpc.GuestRequest, r
 		},
 		HostConfig: &docker.HostConfig{
 			PublishAllPorts: true,
+			// Expose /dev/zfs inside all containers (okay because they are unprivileged)
+			Devices: []docker.Device{
+				docker.Device{
+					PathOnHost: "/dev/zfs",
+					PathInContainer: "/dev/zfs",
+					CgroupPermissions: "rwm",
+				},
+			},
 		},
 	}
 	container, err := md.client.CreateContainer(opts)


### PR DESCRIPTION
This seems to work, but is there a way I can get the runconfig.DeviceMapping type without importing runconfig?
docker.HostConfig is exposed and one of its members is a []DeviceMapping.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent-docker/9)

<!-- Reviewable:end -->
