### PR TITLE
MIST-513 OVS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ into Docker
 #### func (*MDocker) PauseContainer
 
 ```go
-func (md *MDocker) PauseContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestRequest) error
+func (md *MDocker) PauseContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestResponse) error
 ```
 PauseContainer pauses a Docker container
 
 #### func (*MDocker) RebootContainer
 
 ```go
-func (md *MDocker) RebootContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestRequest) error
+func (md *MDocker) RebootContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestResponse) error
 ```
 RebootContainer restarts a Docker container
 
@@ -185,7 +185,7 @@ stored in interface{} don't convert directly, so use JSON as an intermediate
 #### func (*MDocker) RestartContainer
 
 ```go
-func (md *MDocker) RestartContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestRequest) error
+func (md *MDocker) RestartContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestResponse) error
 ```
 RestartContainer restarts a Docker container
 
@@ -213,14 +213,14 @@ StartContainer starts a Docker container
 #### func (*MDocker) StopContainer
 
 ```go
-func (md *MDocker) StopContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestRequest) error
+func (md *MDocker) StopContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestResponse) error
 ```
 StopContainer stops a Docker container or kills it after a timeout
 
 #### func (*MDocker) UnpauseContainer
 
 ```go
-func (md *MDocker) UnpauseContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestRequest) error
+func (md *MDocker) UnpauseContainer(h *http.Request, request *rpc.GuestRequest, response *rpc.GuestResponse) error
 ```
 UnpauseContainer restarts a Docker container
 

--- a/net.go
+++ b/net.go
@@ -1,0 +1,61 @@
+package mdocker
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/mistifyio/mistify-agent/client"
+)
+
+// addInterfaces adds network interfaces to a guest container
+func addInterfaces(g *client.Guest) error {
+	command := "ovs-docker"
+	for _, nic := range g.Nics {
+		args := []string{"add-port",
+			nic.Network,
+			nic.Name,
+			g.Id,
+			"--macaddress=" + nic.Mac, // ovs-docker errors if separate
+		}
+		if output, err := exec.Command(command, args...).CombinedOutput(); err != nil {
+			e := fmt.Errorf("failed to add interface %s", nic.Name)
+			log.WithFields(log.Fields{
+				"error":   err,
+				"command": command,
+				"args":    args,
+				"output":  string(output),
+			}).Error(e)
+			return e
+		}
+	}
+	return nil
+}
+
+// removeInterfaces removes network interfaces from a guest container
+func removeInterfaces(g *client.Guest) error {
+	command := "ovs-docker"
+	for _, nic := range g.Nics {
+		args := []string{
+			"del-port",
+			nic.Network,
+			nic.Name,
+			g.Id,
+		}
+		if output, err := exec.Command(command, args...).CombinedOutput(); err != nil {
+			// Ignore errors when trying to remove interface that is already gone
+			if !strings.Contains(strings.ToLower(string(output)), "failed to find any attached port") {
+				e := fmt.Errorf("failed to remove interface %s", nic.Name)
+				log.WithFields(log.Fields{
+					"error":   err,
+					"command": command,
+					"args":    args,
+					"output":  string(output),
+				}).Error(e)
+				return e
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Creates new containers with `NetworkMode: none` so that docker doesn't try to set up networking automatically. On guest start, use `ovs-docker` to create/add the interface(s). On guest stop, remove the interface(s).

Also includes a small response type fix (several methods were sending back GuestRequest json instead of GuestResponse, though the effect was minor).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent-docker/15)

<!-- Reviewable:end -->
