### PR TITLE
MIST-552 Port vlan tagging

### DIFF
--- a/net.go
+++ b/net.go
@@ -3,31 +3,100 @@ package mdocker
 import (
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/mistifyio/mistify-agent/client"
 )
 
+func getPortForContainerInterface(guestID, ifaceName string) (string, error) {
+	command := "ovs-vsctl"
+	args := []string{
+		"--data=bare",
+		"--no-heading",
+		"--columns=name",
+		"find",
+		"interface",
+		"external_ids:container_id=" + guestID,
+		"external_ids:container_iface=" + ifaceName,
+	}
+	output, err := exec.Command(command, args...).CombinedOutput()
+	if err != nil {
+		e := fmt.Errorf("failed to look up name of interface %s for guest %s",
+			ifaceName,
+			guestID,
+		)
+		log.WithFields(log.Fields{
+			"error":   err,
+			"command": command,
+			"args":    args,
+			"output":  string(output),
+		}).Error(e)
+		return "", e
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func addPort(g *client.Guest, nic client.Nic) (string, error) {
+	command := "ovs-docker"
+	args := []string{"add-port",
+		nic.Network,
+		nic.Name,
+		g.Id,
+		"--macaddress=" + nic.Mac, // ovs-docker errors if separate
+	}
+	if output, err := exec.Command(command, args...).CombinedOutput(); err != nil {
+		e := fmt.Errorf("failed to add interface %s", nic.Name)
+		log.WithFields(log.Fields{
+			"error":   err,
+			"command": command,
+			"args":    args,
+			"output":  string(output),
+		}).Error(e)
+		return "", e
+	}
+	return getPortForContainerInterface(g.Id, nic.Name)
+}
+
+func tagPort(port string, vlanInts []int) error {
+	command := "ovs-vsctl"
+
+	vlans := make([]string, len(vlanInts), len(vlanInts))
+	for i := 0; i < len(vlanInts); i++ {
+		vlans[i] = strconv.Itoa(vlanInts[i])
+	}
+
+	args := []string{
+		"set",
+		"port",
+		port,
+		"trunks=" + strings.Join(vlans, ","),
+	}
+
+	if output, err := exec.Command(command, args...).CombinedOutput(); err != nil {
+		e := fmt.Errorf("failed to tag interface %s", port)
+		log.WithFields(log.Fields{
+			"error":   err,
+			"command": command,
+			"args":    args,
+			"output":  string(output),
+		}).Error(e)
+		return e
+	}
+
+	return nil
+}
+
 // addInterfaces adds network interfaces to a guest container
 func addInterfaces(g *client.Guest) error {
-	command := "ovs-docker"
 	for _, nic := range g.Nics {
-		args := []string{"add-port",
-			nic.Network,
-			nic.Name,
-			g.Id,
-			"--macaddress=" + nic.Mac, // ovs-docker errors if separate
+		port, err := addPort(g, nic)
+		if err != nil {
+			return err
 		}
-		if output, err := exec.Command(command, args...).CombinedOutput(); err != nil {
-			e := fmt.Errorf("failed to add interface %s", nic.Name)
-			log.WithFields(log.Fields{
-				"error":   err,
-				"command": command,
-				"args":    args,
-				"output":  string(output),
-			}).Error(e)
-			return e
+		if err := tagPort(port, nic.VLANs); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Since the `ovs-vsctl` command doesn't support trunk (multiple vlan)
tagging, need to look up the port name and do it ourselves. Bit of
refactoring to keep things clear.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/mistify-agent-docker/16)

<!-- Reviewable:end -->
